### PR TITLE
[FIX]: remove testing keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
         "cli",
         "google",
         "google for testing",
-        "testing",
         "console"
     ],
     "type": "project",


### PR DESCRIPTION
Apparently some keywords trigger the addition of `--dev` in `composer require`, in this case is the testing word